### PR TITLE
Add open-estimate impact-common repos

### DIFF
--- a/risingverse.yml
+++ b/risingverse.yml
@@ -20,3 +20,5 @@ dependencies:
   - pip:
     - impactlab-tools
     - metacsv
+    - git+https://github.com/ClimateImpactLab/open-estimate@master
+    - git+https://github.com/ClimateImpactLab/impact-common@master


### PR DESCRIPTION
This addition now installs impact-common and open-estimate from their `master` branches by default with the environment.