### PR TITLE
Upgrade Python release, drop cruft packages

### DIFF
--- a/risingverse.yml
+++ b/risingverse.yml
@@ -6,7 +6,7 @@ dependencies:
   - click
   - emcee
   - numpy>=1.14
-  - netCDF4=1.3.1
+  - netCDF4>=1.3.1
   - pandas=0.25  # Move to v1 if no deprecation warnings.
   - pip
   - python=3.7

--- a/risingverse.yml
+++ b/risingverse.yml
@@ -5,13 +5,11 @@ channels:
 dependencies:
   - click
   - emcee
-  - gspread=3.1.0
   - numpy>=1.14
   - netCDF4=1.3.1
-  - oauth2client
   - pandas=0.25  # Move to v1 if no deprecation warnings.
   - pip
-  - python=3.6
+  - python=3.7
   - pyyaml
   - pytest
   - scipy


### PR DESCRIPTION
Dropped unused cruft packages, allowing us to bump up the Python version.