### PR TITLE
Bump pkg versions for new py37

### DIFF
--- a/risingverse.yml
+++ b/risingverse.yml
@@ -7,11 +7,11 @@ dependencies:
   - emcee
   - gspread=3.1.0
   - numpy>=1.14
-  - netCDF4=1.3.1
+  - netCDF4>=1.3.1
   - oauth2client
-  - pandas=0.25  # Move to v1 if no deprecation warnings.
+  - pandas=0.25
   - pip
-  - python=3.6
+  - python=3.7
   - pyyaml
   - pytest
   - scipy
@@ -22,3 +22,4 @@ dependencies:
     - metacsv
     - git+https://github.com/ClimateImpactLab/open-estimate@master
     - git+https://github.com/ClimateImpactLab/impact-common@master
+    


### PR DESCRIPTION
Updates python version to 3.7.

Needed to loosen the netcdf4 package version to >= 1.3.1 to get the env to resolve.