### PR TITLE
Drop google spreadsheet pkgs

### DIFF
--- a/risingverse.yml
+++ b/risingverse.yml
@@ -5,10 +5,8 @@ channels:
 dependencies:
   - click
   - emcee
-  - gspread=3.1.0
   - numpy>=1.14
   - netCDF4>=1.3.1
-  - oauth2client
   - pandas=0.25
   - pip
   - python=3.7


### PR DESCRIPTION
Removed packages are unused. Including them creates issues with downstream package imports which seem to depend on deprecated APIs...?